### PR TITLE
install: rework -

### DIFF
--- a/install
+++ b/install
@@ -1,53 +1,87 @@
 #!/usr/local/bin/python3
+'''
+autolite installation tool.
+
+Usage:
+    install [--verify] [-v | -vv | -vvv]
+
+Options:
+    -h --help               Show this screen.
+    --version               Show version.
+    -v --verbose            Higher verbosity messages.
+    --verify                Only verify, without installing missing packagaes.
+'''
 
 import os
 import sys
 
+import consts
 from common import system_out
 from verbosity import verbose, set_verbosity
 from dependencies import DEPENDENCIES
 
+_, SELF_FULL_DIR, _ = consts.get_self_path_dir(__file__)
+
+
+def read_pip_list_dict() -> dict():
+    return dict(entry.split(' ') for entry in system_out('pip3 list').split('\n') if entry)
+
+
+def missing_iter():
+    installed = read_pip_list_dict()
+
+    for package, version in DEPENDENCIES.items():
+        try:
+            assert installed[package] >= '({})'.format(version)
+            verbose(1, 'installed: {}.'.format(_pip_entry(package, version)))
+
+        except (KeyError, AssertionError):
+            yield package, version
+
 
 def install():
     failed = {}
-    _installed = system_out('pip3 list')
 
-    for package, version in DEPENDENCIES.items():
-        if pip_entry(package, version) not in _installed:
-            if os.system('pip3 install {pkg}=={ver}'.format(pkg=package, ver=version)):
-                verbose(1, '[!] failed installation of package:', pip_entry(package, version))
-                failed.update({package: version})
+    for package, version in missing_iter():
+        verbose(1, 'missing: {} - installing...'.format(_pip_entry(package, version)))
 
-    return failed
-
-
-def verify():
-    missing = {}
-    _installed = system_out('pip3 list')
-
-    for package, version in DEPENDENCIES.items():
-        if pip_entry(package, version) not in _installed:
-            missing.update({package: version})
-
-    if missing:
-        print('[x] missing packages:')
-        print('\n\t'.join('{} ({})'.format(*pv) for pv in DEPENDENCIES.items()))
-        sys.exit(1)
-
-    else:
-        verbose(1, '[v] autolite installed Ok.')
-
-
-def pip_entry(pkg, ver):
-    return '{} ({})'.format(pkg, ver)
-
-
-if __name__ == '__main__':
-    set_verbosity(1)
-    failed = install()
+        if os.system('pip3 install {pkg}=={ver}'.format(pkg=package, ver=version)):
+            verbose(1, '[!] failed installation of package: ' + _pip_entry(package, version))
+            failed.update({package: version})
 
     if failed:
         print('[x]', len(failed), 'failed installations')
         sys.exit(1)
 
-    verify()
+
+def verify():
+    missing = dict((pack, ver) for pack, ver in missing_iter())
+
+    if missing:
+        print('[x] missing packages:')
+        print('\t' + '\n\t'.join(_pip_entry(*pv) for pv in missing.items()))
+        sys.exit(1)
+
+
+def _pip_entry(pack, ver):
+    return '{} ({})'.format(pack, ver)
+
+
+if __name__ == '__main__':
+    from docopt import docopt
+
+    with open(os.path.join(SELF_FULL_DIR, 'version')) as ver_file:
+        arguments = docopt(__doc__, version=ver_file.read())
+
+    set_verbosity(arguments['--verbose'])
+
+    if arguments['--verbose'] > 1:
+        print(arguments)
+
+    if arguments['--verify']:
+        verify()
+
+    else:
+        install()
+
+    verbose(1, '[v] autolite is well installed.')


### PR DESCRIPTION
```
1. amend pip install criteria to version > installed.
2. refactor missing package loop, to reused iter().
3. add docopt.
4. set global verbosity.
5. separate install & verify procedures.
```
